### PR TITLE
Fix: do not fail if folder contains non-rolling-file produced files

### DIFF
--- a/bin/rolling-file-name.js
+++ b/bin/rolling-file-name.js
@@ -85,7 +85,7 @@ FileName.fileName = function(configuration, date, index) {
  */
 FileName.increment = function(fileName) {
     var o = FileName.components(fileName);
-    if (typeof o.index === 'undefined') return fileName;
+    if (!o || typeof o.index === 'undefined') return fileName;
     return (o.fileName ? o.fileName + '.' : '') +
         o.dateString + '.' +
         (o.index + 1) +
@@ -107,12 +107,14 @@ FileName.matches = function(fileNames, configuration, date) {
 
     fileNames.forEach(function(fileName) {
         var o = FileName.components(fileName);
-        var match = ((!config.fileName && typeof o.fileName === 'undefined') || config.fileName === o.fileName) &&
-            ((!config.fileExtension && typeof o.extension === 'undefined') || config.fileExtension === o.extension) &&
-            ((!config.interval && typeof o.index === 'undefined') || (config.interval && typeof o.index !== 'undefined')) &&
-            (!config.interval || moment(o.dateString, 'YYYY-MM-DD-HHmmss').toDate().getTime() % config.interval === config.startOfDay) &&
-            (!dtString || dtString === o.dateString);
-        if (match) results.push(o);
+        if (o) {
+            var match = ((!config.fileName && typeof o.fileName === 'undefined') || config.fileName === o.fileName) &&
+              ((!config.fileExtension && typeof o.extension === 'undefined') || config.fileExtension === o.extension) &&
+              ((!config.interval && typeof o.index === 'undefined') || (config.interval && typeof o.index !== 'undefined')) &&
+              (!config.interval || moment(o.dateString, 'YYYY-MM-DD-HHmmss').toDate().getTime() % config.interval === config.startOfDay) &&
+              (!dtString || dtString === o.dateString);
+            if (match) results.push(o);
+        }
     });
 
     return results;

--- a/test/rolling-file-path.test.js
+++ b/test/rolling-file-path.test.js
@@ -63,6 +63,10 @@ describe('rolling-file-path', function() {
 
     describe('#components', function() {
 
+        it('null for a non-matching file', function() {
+            expect(rfName.components('qwe')).to.be.null;
+        });
+
         it('no filename, no index, no extension', function() {
             var o = rfName.components('2000-01-01-000000');
             expect(o.date.getTime()).to.equal(new Date(2000, 0, 1, 0, 0, 0).getTime());
@@ -320,6 +324,11 @@ describe('rolling-file-path', function() {
             expect(function() { rfName.increment(null); }).to.throw(Error);
         });
 
+        it('non-rolling-file file name', function() {
+            var fileName = 'stdout.log';
+            expect(rfName.increment(fileName)).to.be.equal(fileName);
+        });
+
         it('file name without index', function() {
             var fileName = 'foo.2000-01-01-000000.bar';
             expect(rfName.increment(fileName)).to.be.equal(fileName);
@@ -516,6 +525,18 @@ describe('rolling-file-path', function() {
                 final.sort();
 
                 expect(rfName.matches(final, config, date).map(mapFull)).to.deep.equal(matches);
+            });
+
+        });
+
+        describe('non rolling-file produced log files', function() {
+
+            it('ignored', function() {
+                var nonMatches = [
+                    'stdout.log'
+                ];
+
+                expect(rfName.matches(nonMatches, { fileName: ''}).map(mapFull)).to.deep.equal([]);
             });
 
         });


### PR DESCRIPTION
I tried to stay consistent with existing test naming and formatting.